### PR TITLE
Change syntax of ARM template output

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -1,11 +1,11 @@
 output "host_name" {
-  value = "${azurerm_template_deployment.redis-paas.outputs.hostName}"
+  value = "${azurerm_template_deployment.redis-paas.outputs["hostName"]}"
 }
 
 output "access_key" {
-  value = "${azurerm_template_deployment.redis-paas.outputs.accessKey}"
+  value = "${azurerm_template_deployment.redis-paas.outputs["accessKey"]}"
 }
 
 output "redis_port" {
-  value = "${azurerm_template_deployment.redis-paas.outputs.sslPort}"
+  value = "${azurerm_template_deployment.redis-paas.outputs["sslPort"]}"
 }


### PR DESCRIPTION
The syntax of extracting ARM template outputs changed in Terraform 11.

Changes tested on sandbox/sandbox in SYA application