### PR TITLE
Increase create timeout to 20m

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_redis_cache" "redis" {
   }
 
   timeouts {
-    create = "20 minutes"
+    create = "20m"
   }
 
   tags = "${var.common_tags}"

--- a/main.tf
+++ b/main.tf
@@ -23,5 +23,9 @@ resource "azurerm_redis_cache" "redis" {
     maxmemory_policy = "${var.maxmemory_policy}"
   }
 
+  timeouts {
+    create = 20
+  }
+
   tags = "${var.common_tags}"
 }

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_redis_cache" "redis" {
   }
 
   timeouts {
-    create = 20
+    create = "20 minutes"
   }
 
   tags = "${var.common_tags}"


### PR DESCRIPTION
Using this module, I have experienced no successful deployments. Perhaps a degradation of the redis service in Azure is causing longer than usual creation times but this PR increases the timeout from 10m to 20m which I have found to succeed.

Creation failed throughout the weekend except for when creating with a 20m timeout.