### PR TITLE
Subscription ID not needed for validate in 4.0.1

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 
-env:
-  ARM_SUBSCRIPTION_ID: b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb
-
 jobs:
   terraform:
     name: "terraform"


### PR DESCRIPTION
see https://github.com/hashicorp/terraform-provider-azurerm/issues/27154#issuecomment-2307619896