### PR TITLE
Adds data_persistence_authentication_method default to SAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you need to increase cache size take a look at the [pricing page](https://azu
 | <a name="input_business_area"></a> [business\_area](#input\_business\_area) | business\_area name - sds or cft | `string` | `"cft"` | no |
 | <a name="input_capacity"></a> [capacity](#input\_capacity) | The size of the Redis cache to deploy. Valid values are 1, 2, 3, 4, 5 | `string` | `"1"` | no |
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Map of tags to tag all resources with | `map(string)` | n/a | yes |
+| <a name="input_data_persistence_authentication_method"></a> [data\_persistence\_authentication\_method](#input\_data\_persistence\_authentication\_method) | n/a | `string` | `"SAS"` | no |
 | <a name="input_env"></a> [env](#input\_env) | Environment to deploy to | `string` | n/a | yes |
 | <a name="input_family"></a> [family](#input\_family) | The SKU family/pricing group to use. Valid values are `C` (for Basic/Standard SKU family) and `P` (for Premium). Use P for higher availability, but beware it costs a lot more. | `string` | `"P"` | no |
 | <a name="input_location"></a> [location](#input\_location) | Azure datacenter location | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -20,10 +20,10 @@ resource "azurerm_redis_cache" "redis" {
 
   redis_configuration {
     data_persistence_authentication_method = var.data_persistence_authentication_method
-    maxmemory_reserved              = var.maxmemory_reserved
-    maxfragmentationmemory_reserved = var.maxfragmentationmemory_reserved
-    maxmemory_delta                 = var.maxmemory_delta
-    maxmemory_policy                = var.maxmemory_policy
+    maxmemory_reserved                     = var.maxmemory_reserved
+    maxfragmentationmemory_reserved        = var.maxfragmentationmemory_reserved
+    maxmemory_delta                        = var.maxmemory_delta
+    maxmemory_policy                       = var.maxmemory_policy
   }
 
   tags = var.common_tags

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "azurerm_redis_cache" "redis" {
   zones                         = var.availability_zones
 
   redis_configuration {
+    data_persistence_authentication_method = var.data_persistence_authentication_method
     maxmemory_reserved              = var.maxmemory_reserved
     maxfragmentationmemory_reserved = var.maxfragmentationmemory_reserved
     maxmemory_delta                 = var.maxmemory_delta

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,11 @@ variable "resource_group_name" {
   type        = string
   default     = null
 }
+
+variable "data_persistence_authentication_method" {
+  default = "SAS"
+  validation {
+    condition     = contains(["SAS", "ManagedIdentity"], var.data_persistence_authentication_method)
+    error_message = "Must be either \"SAS\" or \"ManagedIdentity\"."
+  }
+}


### PR DESCRIPTION
I'm seeing an update to terraform which is showing me this in the plan:

```tf
redis_configuration {
          - data_persistence_authentication_method  = "SAS" -> null
```

Which I don't think we want..
Docs don't say what the default is (guess it used to be `SAS`...)

> data_persistence_authentication_method - (Optional) Preferred auth method to communicate to storage account used for data persistence. Possible values are SAS and ManagedIdentity.

This PR adds `data_persistence_authentication_method` as a variable and defaults it to `SAS` so that no changes should be made when updating redis